### PR TITLE
Export mocha results to sauce

### DIFF
--- a/lib/js-testing-reporter-adapter/mocha-reporter.js
+++ b/lib/js-testing-reporter-adapter/mocha-reporter.js
@@ -21,7 +21,7 @@ window.mocha && (JSTestingReporterSL = (function(undefined) {
       passedCount : isPassed ? 1 : 0,
       failedCount : isPassed ? 0 : 1,
       totalCount  : 1
-    }
+    };
   }
 
   function emptyReporter() {
@@ -30,7 +30,7 @@ window.mocha && (JSTestingReporterSL = (function(undefined) {
       durationSec : 0,
       passed      : true,
       totalCount  : 0
-    }
+    };
   }
 
   function reporterObjects(objs, fn) {
@@ -53,7 +53,7 @@ window.mocha && (JSTestingReporterSL = (function(undefined) {
   }
 
   function reporterSuites(suites) {
-    return reporterObjects(suites, reporterSuite);;
+    return reporterObjects(suites, reporterSuite);
   }
 
   function reporterSuite(suite) {
@@ -67,10 +67,19 @@ window.mocha && (JSTestingReporterSL = (function(undefined) {
       durationSec : specs.durationSec + suites.durationSec,
       totalCount  : specs.totalCount + suites.totalCount,
       passed      : specs.passed && suites.passed
-    }
+    };
   }
 
   return function() {
+    if ('global_test_results' in window) {
+      return {
+        passed: !!(global_test_results && global_test_results.failures === 0),
+        'custom-data': {
+          mocha: global_test_results
+        }
+      };
+    }
+
     return reporterSuite(mocha.suite).suites[0];
-  }
+  };
 })());


### PR DESCRIPTION
Forwards `global_test_results` when detected