### PR TITLE
Support for tap output

### DIFF
--- a/lib/sauce-conf.js
+++ b/lib/sauce-conf.js
@@ -89,6 +89,11 @@ var webdriver   = require('wd'),
       .options('timeout', {
           'describe': 'Timeout in seconds until tests need to finish'
       })
+      .options('tap', {
+        'default':  false,
+        'boolean':  true,
+        'describe': 'Output results in the TAP format'
+      })
       .string('versionSL')
       .argv,
 

--- a/lib/sauce-tap-output.js
+++ b/lib/sauce-tap-output.js
@@ -1,0 +1,57 @@
+'use strict';
+var intercept = require("intercept-stdout");
+var tapping = false;
+
+// http://testanything.org/tap-specification.html
+
+function prefixLines(prefix, lines) {
+  return prefix + lines.replace(/((?:\r\n|\n|\r).)/g, function(match, p1) {
+    return p1 + prefix;
+  });
+}
+
+exports.interceptOutput = function() {
+  intercept(function(txt) {
+    if (tapping) {
+      return txt;
+    }
+
+    return prefixLines('## ', txt);
+  });
+};
+
+exports.putPlanError = function(err) {
+  tapping = true;
+
+  console.error(
+    '1..0 # Skipped: '
+    + err.message + '\n'
+    + prefixLines('#', err.stack)
+  );
+
+  tapping = false;
+};
+
+exports.putPlan = function(resultScript) {
+  tapping = true;
+
+  console.log('%d..%d', 1, resultScript.totalCount);
+
+  var passes = 0;
+  var failures = 0;
+  resultScript.specs.forEach(function (spec, index) {
+    passes += spec.passedCount;
+    failures += spec.failedCount;
+
+    console.log('%s %d %s',
+      spec.passed ? 'ok' : 'not ok',
+      index + 1,
+      spec.description.replace(/#/g, '')
+    );
+  });
+
+  console.log('# tests %d', passes + failures);
+  console.log('# pass %d', passes);
+  console.log('# fail %d', failures);
+  tapping = false;
+};

--- a/lib/saucelauncher-webdriver.js
+++ b/lib/saucelauncher-webdriver.js
@@ -3,12 +3,17 @@ var async           = require('async'),
     config          = require('./sauce-conf.js'),
     integrationTest = require('./sauce-javascript-tests-integration.js'),
     updateJobStatus = require('./sauce-update-job-status.js'),
-    loadJsReporter  = require('./sauce-js-testing-reporter.js');
+    loadJsReporter  = require('./sauce-js-testing-reporter.js'),
+    tapOutput       = require('./sauce-tap-output');
 
 module.exports = function(options, callback) {
   var argv               = config.set(options),
       auth               = config.auth(),
       integrationTestURL = argv.url;
+
+  if (argv.tap) {
+    tapOutput.interceptOutput();
+  }
 
   if (!auth.username || !auth.accessKey) {
     var msg = "Please, provide the username and the access key for SauceLabs. Use the option --help for more information.";
@@ -89,7 +94,18 @@ module.exports = function(options, callback) {
       });
     }
   ], function (err, result) {
-    err && console.error(err);
+    if (argv.tap) {
+      if (err) {
+        tapOutput.putPlanError(err);
+      } else if (!result.resultScript) {
+        tapOutput.putPlanError(Error('Did not receive a "resultScript"'));
+      } else {
+        tapOutput.putPlan(result.resultScript);
+      }
+
+    } else {
+      err && console.error(err);
+    }
     callback && callback( err, result );
   });
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "extend": "^2.0.0",
+    "intercept-stdout": "^0.1.1",
     "optimist": "^0.6.0",
     "q": "^1.1.2",
     "request": "^2.51.0",


### PR DESCRIPTION
I was playing around a bit with this library & testem. I added a launcher to my testem.json:

```json
"launchers": {
    "SL_Chrome_latest": {
      "command": "\"node_modules/.bin/saucie\" -u http://localhost:7357/ -b googlechrome",
      "protocol": "tap"
    },
}
```

I noticed that I only got a singular pass/fail result in testem, instead of a total count. So I added an argument to saucie to output the results of all test cases in TAP format:

```json
"launchers": {
    "SL_Chrome_latest": {
      "command": "\"node_modules/.bin/saucie\" --tap -u http://localhost:7357/ -b googlechrome",
      "protocol": "tap"
    },
}
```

This is the first time I am trying out SauceLabs so there might be some mistakes. 

I used a library to intercept output (console.log, etc) so that I can that output them as TAP diagnostic lines (beginning with a `#`) instead. This works for me, but it might not be considered clean enough to merge. I wanted to get this working quickly (at least for now).

Here is a sample of my TAP output:

```tap
## Testing tunnel ready
## Started Sauce Connect Process
## Starting run all tests against Sauce Labs
## Updating job status
## not ok
## Closed browser.
## Closing Sauce Connect Tunnel
## Closed Sauce Connect process
1..1145
not ok 1 test case that always fails
ok 2 foo bar test case
ok 3 1 < 2
ok 4 1/0 === Infinity
```
I am outputting a double `#` because some diagnostic lines have special meaning in TAP