### PR TITLE
Added a command line option to set vm-version to varnish

### DIFF
--- a/lib/argv.js
+++ b/lib/argv.js
@@ -85,5 +85,8 @@ module.exports = optimist
   .options('timeout', {
       'describe': 'Timeout in seconds until tests need to finish'
   })
+  .options('vmVersion', {
+      'describe': 'Choose dev-varnish to enable websocket support'
+  })
   .string('versionSL')
   .argv;

--- a/lib/sauce-conf.js
+++ b/lib/sauce-conf.js
@@ -37,6 +37,7 @@ function Config (options) {
     username: this._auth.username,
     accessKey: this._auth.accessKey,
     tunnelIdentifier: this._auth.tunnelIdentifier,
+    vmVersion: this.options.vmVersion,
     logger: console.log,
     verbose: true
   };


### PR DESCRIPTION
This adds the option to set the proxy from squid to dev-varnish so that websockets will work when testing against a localhost server. SauceLabs recommends it here: https://support.saucelabs.com/customer/en/portal/questions/12843813 and I didn't see an existing way to set it.