### PR TITLE
Added tunnelDomains option to allow setting a non-local host

### DIFF
--- a/lib/argv.js
+++ b/lib/argv.js
@@ -88,5 +88,8 @@ module.exports = optimist
   .options('vmVersion', {
       'describe': 'Choose dev-varnish to enable websocket support'
   })
+  .options('tunnelDomains', {
+      'describe': 'A comma separated list of domains to send through the tunnel'
+  })
   .string('versionSL')
   .argv;

--- a/lib/sauce-conf.js
+++ b/lib/sauce-conf.js
@@ -38,6 +38,7 @@ function Config (options) {
     accessKey: this._auth.accessKey,
     tunnelIdentifier: this._auth.tunnelIdentifier,
     vmVersion: this.options.vmVersion,
+    tunnelDomains: this.options.tunnelDomains,
     logger: console.log,
     verbose: true
   };


### PR DESCRIPTION
Safari throws a fit when using websockets on localhost. This allows something like `example.com` to be forced through the tunnel.

P.S. I'm wondering if there would be a more flexible way for saucie to allow arbitrary options to be passed? There's quite a lot of options in Sauce Connect if it's going to support them all.