### PR TITLE
coerce deviceName to String

### DIFF
--- a/lib/argv.js
+++ b/lib/argv.js
@@ -23,7 +23,8 @@ module.exports = optimist
   .options('versionSL', {
     'alias':    'v',
     'default':  '',
-    'describe': 'Define the browser version'
+    'describe': 'Define the browser version',
+    'string': true
   })
   .options('platformSL', {
     'alias':    'p',


### PR DESCRIPTION
The SauceLabs API requires this option to be a string.