### PR TITLE
Remove Node 0.10 / 0.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: node_js
 node_js:
-  - "0.10"
   - '4'
   - '6'
   - '7'
@@ -9,7 +8,7 @@ node_js:
 sudo: false
 
 before_install:
-  - "npm config set spin false"
+  - npm config set spin false
 
 env:
   global:


### PR DESCRIPTION
According to https://github.com/nodejs/LTS Node 0.10 has already reached
EOL and 0.12 will reach it soon.