### PR TITLE
fix device orientation setting

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -15,17 +15,17 @@ function Config (options) {
   };
 
   this._desired = {
-    "browserName": this.options.browserNameSL,
-    "version"    : this.options.versionSL,
-    "platform"   : this.options.platformSL,
-    "deviceName" : this.options.deviceNameSL,
-    "device-orientation": this.options.deviceOrientationSL,
-    "tags"       : this.options.tagsSL,
-    "name"       : this.options.sessionNameSL,
-    "public"     : this.options.visibilitySL,
-    "build"      : this._auth.build,
+    "browserName"      : this.options.browserNameSL,
+    "version"          : this.options.versionSL,
+    "platform"         : this.options.platformSL,
+    "deviceName"       : this.options.deviceNameSL,
+    "deviceOrientation": this.options.deviceOrientationSL,
+    "tags"             : this.options.tagsSL,
+    "name"             : this.options.sessionNameSL,
+    "public"           : this.options.visibilitySL,
+    "build"            : this._auth.build,
     "tunnel-identifier": this._auth.tunnelIdentifier,
-    "record-video": true
+    "record-video"     : true
   };
 
   this.url = this.options.url;


### PR DESCRIPTION
According to the [SourceLabs Platform Configurator](https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/) it's `deviceOrientation` not `device-orientation` (which is also not in line with any of the other settings).