### PR TITLE
allow requesting specific platform version

### DIFF
--- a/lib/argv.js
+++ b/lib/argv.js
@@ -26,10 +26,16 @@ module.exports = optimist
     'describe': 'Define the browser version',
     'string': true
   })
-  .options('platformSL', {
+  .options('platformNameSL', {
     'alias':    'p',
     'default':  '',
-    'describe': "Define the platform to run the tests, e.g: 'Linux', 'Windows 7', 'Windows XP', 'OS X 10.6'"
+    'describe': "Define the platform to run the tests, e.g: 'Linux', 'Windows', 'iOS'"
+  })
+  .options('platformVersionSL', {
+    'alias':    'pv',
+    'default':  '',
+    'describe': "Define the platform version to run the tests, e.g: 'XP', '9.3'",
+    'string': true
   })
   .options('deviceNameSL', {
     'alias':    'dn',

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,7 +17,7 @@ function Config (options) {
   this._desired = {
     "browserName"      : this.options.browserNameSL,
     "version"          : this.options.versionSL,
-    "platform"         : this.options.platformSL,
+    "platform"         : '',
     "deviceName"       : this.options.deviceNameSL,
     "deviceOrientation": this.options.deviceOrientationSL,
     "tags"             : this.options.tagsSL,
@@ -27,6 +27,17 @@ function Config (options) {
     "tunnel-identifier": this._auth.tunnelIdentifier,
     "record-video"     : true
   };
+
+  if (this.options.platformNameSL) {
+    this._desired.platformName = this.options.platformNameSL;
+    this._desired.platform     = this._desired.platformName;
+  }
+  if (this.options.platformVersionSL) {
+    this._desired.platformVersion = this.options.platformVersionSL;
+    if (this._desired.platform) {
+      this._desired.platform += ' ' + this._desired.platformVersion;
+    }
+  }
 
   this.url = this.options.url;
   this.timeout = this.options.timeout;


### PR DESCRIPTION
This allows running tests on a particular version of the target OS which is especially helpful for mobile devices where there's only one browser version per OS version so being able to request a particular browser version doesn't help much.

Closes #53 