### PR TITLE
Fix desktop browsers

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,26 +16,32 @@ function Config (options) {
 
   this._desired = {
     "browserName"      : this.options.browserNameSL,
-    "version"          : this.options.versionSL,
-    "platform"         : '',
     "deviceName"       : this.options.deviceNameSL,
     "deviceOrientation": this.options.deviceOrientationSL,
     "tags"             : this.options.tagsSL,
     "name"             : this.options.sessionNameSL,
     "public"           : this.options.visibilitySL,
     "build"            : this._auth.build,
-    "tunnel-identifier": this._auth.tunnelIdentifier,
-    "record-video"     : true
+    "tunnelIdentifier" : this._auth.tunnelIdentifier
   };
 
-  if (this.options.platformNameSL) {
-    this._desired.platformName = this.options.platformNameSL;
-    this._desired.platform     = this._desired.platformName;
+  if (this.options.versionSL) {
+    this._desired.version = this.options.versionSL;
   }
-  if (this.options.platformVersionSL) {
-    this._desired.platformVersion = this.options.platformVersionSL;
-    if (this._desired.platform) {
-      this._desired.platform += ' ' + this._desired.platformVersion;
+
+  if (this.options.platformNameSL.match(/iOS|Android/)) {
+    // Appium requires to seperate strings, https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Appium-SpecificOptions
+    this._desired.platformName = this.options.platformNameSL;
+
+    if (this.options.platformVersionSL) {
+      this._desired.platformVersion = this.options.platformVersionSL;
+    }
+  } else {
+    // Selenium just one
+    this._desired.platform = this.options.platformNameSL || '';
+
+    if (this.options.platformVersionSL) {
+      this._desired.platform += ' ' + this.options.platformVersionSL;
     }
   }
 

--- a/test/integration/qunit_test.js
+++ b/test/integration/qunit_test.js
@@ -37,6 +37,53 @@ describe('QUnit - Integration', function() {
     });
   });
 
+  it('supports desktop browsers (selenium)', function(done) {
+    launcher({
+      url: url,
+      connectRetries: 2,
+      platformNameSL: 'Windows',
+      platformVersionSL: '10'
+    }, function(err, result) {
+      if (err) {
+        return done(err);
+      }
+
+      expect(result).to.have.deep.property('body.passed', true, 'Marked tests as passed');
+      expect(result).to.have.deep.property('body.custom-data.qunit');
+
+      var qunitResult = result.body['custom-data'].qunit;
+      expect(qunitResult.failed).to.eq(0);
+      expect(qunitResult.passed).to.eq(4);
+      expect(qunitResult.total).to.eq(4);
+      done();
+    });
+  });
+
+  it('supports mobile browsers (appium)', function(done) {
+    launcher({
+      rl: url,
+      connectRetries: 2,
+      browserNameSL: 'Browser',
+      deviceNameSL: 'Android Emulator',
+      deviceOrientationSL: 'portrait',
+      platformNameSL: 'Android',
+      platformVersionSL: '5.1'
+    }, function(err, result) {
+      if (err) {
+        return done(err);
+      }
+
+      expect(result).to.have.deep.property('body.passed', true, 'Marked tests as passed');
+      expect(result).to.have.deep.property('body.custom-data.qunit');
+
+      var qunitResult = result.body['custom-data'].qunit;
+      expect(qunitResult.failed).to.eq(0);
+      expect(qunitResult.passed).to.eq(4);
+      expect(qunitResult.total).to.eq(4);
+      done();
+    });
+  });
+
   it('works when controlling the tunnel manually', function() {
     var pidFile = 'sc.pid';
     return connect({


### PR DESCRIPTION
Sending platformName when requesting a desktop browser breaks selenium.
Determine based on the platform, whether selenium or appium should be
used and send the correct properties.

//cc @marcoow looks like https://github.com/johanneswuerbach/saucie/pull/55 broke this for desktop browsers.