### PR TITLE
-u should only be an alias for --url and not --username

### DIFF
--- a/lib/parse-argv.js
+++ b/lib/parse-argv.js
@@ -5,7 +5,7 @@ var defaults = require('./default-options');
 module.exports = function(argv) {
   var result = new commander.Command()
     .description('a JS test runner using Sauce Labs. Supports Mocha, Qunit and Jasmine tests. Please make sure you have a file named testem.yml in the folder.')
-    .option('-u, --username <username>', 'Define the SauceLabs user name [$SAUCE_USERNAME]')
+    .option('-U, --username <username>', 'Define the SauceLabs user name [$SAUCE_USERNAME]')
     .option('-k, --accesskey <key>', 'Define the SauceLabs access key [$SAUCE_ACCESS_KEY]')
     .option('-b, --browser <name>', `Define the browser, e.g.: 'internet explorer', 'firefox', 'chrome' [${defaults.browser}]`, defaults.browser)
     .option('-v, --version <version>', 'Define the browser version', defaults.version)

--- a/test/parse-argv-test.js
+++ b/test/parse-argv-test.js
@@ -170,4 +170,26 @@ describe('parseArgv()', function() {
       expect(result.attach).to.equal(true);
     });
   });
+
+  describe('username', function() {
+    it('defaults to undefined', function() {
+      var result = _parseArgv([]);
+      expect(result.username).to.equal(undefined);
+    });
+
+    it('can be set to test', function() {
+      var result = _parseArgv(['--username', 'test']);
+      expect(result.username).to.equal('test');
+    });
+
+    it('can be set to test using its alias', function() {
+      var result = _parseArgv(['-U', 'test']);
+      expect(result.username).to.equal('test');
+    });
+
+    it('is not aliased to -u', function() {
+      var result = _parseArgv(['-u', 'test']);
+      expect(result.username).to.equal(undefined);
+    });
+  });
 });


### PR DESCRIPTION
While -u was also an alias for --username in optimist, it was never
parsed correctly.