### PR TITLE
support maxDuration option

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -25,6 +25,10 @@ function Config (options) {
     this._desired.version = this.options.version;
   }
 
+  if (this.options.maxDuration) {
+    this._desired.maxDuration = this.options.maxDuration;
+  }
+
   if (this.options.platform.match(/iOS|Android/)) {
     // Appium requires to seperate strings, https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Appium-SpecificOptions
     this._desired.platformName = this.options.platform;

--- a/lib/parse-argv.js
+++ b/lib/parse-argv.js
@@ -26,6 +26,7 @@ module.exports = function(argv) {
     .option('-r, --connect-retries <n>', 'Try establishing the tunnel x times after a failure has occured.', n => parseInt(n, 10), defaults.connectRetries)
     .option('--attach', 'Attach to the launched browser')
     .option('--timeout <timeout>', 'Timeout in seconds until tests need to finish')
+    .option('--max-duration <duration>', "Maximum duration for the Saucelabs session in seconds (Saucelabs's default is 1800; hard limit is 10800)")
     .option('--vmVersion <version>', 'Choose dev-varnish to enable websocket support')
     .option('--tunnelDomains <domains>', 'A comma separated list of domains to send through the tunnel')
     .parse(argv);


### PR DESCRIPTION
This should never be necessary but the sad reality is it sometimes is 😞 

(This prevents tests that run longer than 30min to be force-quite by Saucelabs)