### PR TITLE
chore(): update sauce connect proxy version

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -5,7 +5,7 @@ var sauceConnectLauncherAsync = Bluebird.promisify(sauceConnectLauncher);
 module.exports = function connect(opts) {
   opts = Object.assign({}, opts, {
     detached: true,
-    connectVersion: '4.3.16',
+    connectVersion: '4.4.9',
     connectRetries: 2,
     downloadRetries: 2
   });


### PR DESCRIPTION
Using ember-cli-sauce I get the following message when running ```ember:sauce connect```
```
***********************************************************
A newer version of Sauce Connect (build 3688) is available!
Download it here:
https://saucelabs.com/downloads/sc-4.4.9-osx.zip
***********************************************************
```

https://wiki.saucelabs.com/display/DOCS/Setting+Up+Sauce+Connect+Proxy