### PR TITLE
update(connect): removes predefined sauceConnect version

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -5,7 +5,6 @@ var sauceConnectLauncherAsync = Bluebird.promisify(sauceConnectLauncher);
 module.exports = function connect(opts) {
   opts = Object.assign({}, opts, {
     detached: true,
-    connectVersion: '4.3.16',
     connectRetries: 2,
     downloadRetries: 2
   });


### PR DESCRIPTION
I wasn't able to download the latest version of sauce-connect on my test runs with ember-cli-sauce by default. Does it therefore make sense to change the following?

This removes the pre-set sauceConnectLauncher version number default, allowing - if no other connectionVersion was passed in by the user - to use the default version ("latest") of the connection launcher instead.
See also: https://github.com/bermi/sauce-connect-launcher#advanced-usage
